### PR TITLE
chore: add and configure cloudinary storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,11 @@ asgiref==3.5.2
 certifi==2022.6.15
 cffi==1.15.1
 charset-normalizer==2.1.0
+cloudinary==1.29.0
 cryptography==37.0.4
 defusedxml==0.7.1
 dj-database-url==0.5.0
+dj3-cloudinary-storage==0.0.6
 Django==3.2.14
 django-allauth==0.51.0
 django-model-utils==4.2.0
@@ -19,5 +21,6 @@ python3-openid==3.2.0
 pytz==2022.1
 requests==2.28.1
 requests-oauthlib==1.3.1
+six==1.16.0
 sqlparse==0.4.2
 urllib3==1.26.10

--- a/support_hub/settings.py
+++ b/support_hub/settings.py
@@ -47,11 +47,13 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
-    "django.contrib.staticfiles",
     "django.contrib.sites",
     "allauth",
     "allauth.account",
     "allauth.socialaccount",
+    "cloudinary_storage",
+    "django.contrib.staticfiles",
+    "cloudinary",
     "accounts",
 ]
 
@@ -142,8 +144,14 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 STATIC_URL = "/static/"
+STATICFILES_STORAGE = (
+    "cloudinary_storage.storage.StaticHashedCloudinaryStorage"
+)
 STATICFILES_DIRS = [Path.joinpath(BASE_DIR, "static")]
 STATIC_ROOT = Path.joinpath(BASE_DIR, "staticfiles")
+
+MEDIA_URL = "/media/"
+DEFAULT_FILE_STORAGE = "cloudinary_storage.storage.MediaCloudinaryStorage"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field


### PR DESCRIPTION
Add cloudinary storage packages and settings so the admin site displays correctly when deployed to Heroku.