### PR TITLE
feat: add settings to enable password reset

### DIFF
--- a/support_hub/settings.py
+++ b/support_hub/settings.py
@@ -62,6 +62,29 @@ SITE_ID = 1
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 
+# django-allauth Settings
+ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 2
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"
+ACCOUNT_LOGIN_ATTEMPTS_LIMIT = 5
+ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT = 900  # 15 minutes in seconds
+LOGIN_URL = "/accounts/login/"
+
+# Email Settings
+# CREDIT: Adapted from djangokatya
+# URL: https://djangokatya.com/2020/08/17/django-allauth-tutorial-part-2-email-confirmation/
+if environ.get("DEV_ENVIRONMENT_EMAIL"):
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_USE_TLS = True
+    EMAIL_HOST = "smtp.gmail.com"
+    EMAIL_PORT = 587
+    DEFAULT_FROM_EMAIL = environ.get("EMAIL_HOST_USER")
+    EMAIL_HOST_USER = environ.get("EMAIL_HOST_USER")
+    EMAIL_HOST_PASSWORD = environ.get("EMAIL_HOST_PASSWORD")
+    ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/templates/account/email.html
+++ b/templates/account/email.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "base.html" %}
 
 {% load i18n %}
 

--- a/templates/account/email_confirm.html
+++ b/templates/account/email_confirm.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "base.html" %}
 
 {% load i18n %}
 {% load account %}

--- a/templates/account/password_change.html
+++ b/templates/account/password_change.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "base.html" %}
 
 {% load i18n %}
 

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "base.html" %}
 
 {% load i18n %}
 {% load account %}

--- a/templates/account/password_reset_done.html
+++ b/templates/account/password_reset_done.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "base.html" %}
 
 {% load i18n %}
 {% load account %}

--- a/templates/account/verification_sent.html
+++ b/templates/account/verification_sent.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "base.html" %}
 
 {% load i18n %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,6 +32,7 @@
 
           {% if user.is_authenticated %}
           <span style="right:30px;position:absolute; align-self:center">Logged in as: {{ user.username }}</span>
+          <a class="nav-item nav-link" href="{% url 'account_change_password' %}">Change Password</a>
           <a class="nav-item nav-link" href="{% url 'account_logout' %}">Logout</a>
           {% else %}
           <a class="nav-item nav-link" href="{% url 'account_signup' %}">Register</a>


### PR DESCRIPTION
- The development environment is configured to use the console to verify email addresses whereas the live environment will use a test gmail account. 
- Django-allauth templates have been modified to extend from the base template, additional styling will be added later.
- Password reset link added to navigation when user is logged in.

Completes User Story #7.